### PR TITLE
feat: Add bin command for npx execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ build/Release
 node_modules/
 jspm_packages/
 
+# Build output
+/dist
+
 # Snowpack dependency directory (https://snowpack.dev/)
 web_modules/
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env bun
+
+(async () => {
+    console.log('Inicializando Woovers.js...');
+
+    try{
+        await import('../dist/server.js');
+    } catch (error){
+        console.error('Error: Falha em iniciar a aplicação');
+        if (error.code === 'ERR_MODULE_NOT_FOUND'){
+            console.error('O arquivo "dist/server.js" não foi encontrado. Execute o comando build.');
+        }
+        console.error(error);
+        process.exit(1);
+    }
+})();

--- a/package.json
+++ b/package.json
@@ -4,6 +4,13 @@
   "description": "NodeJS web-server for mimicking the Woovi/OpenPix API",
   "main": "/src/app.ts",
   "type": "module",
+  "bin": {
+    "woovers-js": "bin/cli.js"
+  },
+  "files": [
+    "dist",
+    "bin"
+  ],
   "scripts": {
     "start": "bun src/server.ts",
     "dev": "bun --watch src/server.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
+    "outDir": "./dist",
     "esModuleInterop": true,
-    "types": [],
+    "types": ["bun-types"],
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
@@ -16,10 +17,6 @@
     "isolatedModules": true,
     "noUncheckedSideEffectImports": true,
     "moduleDetection": "force",
-    "skipLibCheck": true,
-    "typeRoots": [
-      "./src/types",
-      "./node_modules/@types"
-    ]
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
Fecha a Issue #5

Este pull request introduz um comando 'bin' para tornar o projeto executável via 'npx', conforme solicitado na Issue #5.

 Adicionado o comando 'bin' ao 'package.json' e criado o script executável 'bin/cli.js'.
 Introduzido um script de 'build' no 'package.json' usando Bun.
 Adicionado o arquivo '.gitignore' para excluir a pasta '/dist'.
 Atualizado o 'tsconfig.json' com uma configuração adequada de 'outDir' para enviar os arquivos .d.ts para a pasta /dist.